### PR TITLE
Fix setting logLevel from config in notification service

### DIFF
--- a/notification/src/utils/logger.js
+++ b/notification/src/utils/logger.js
@@ -1,7 +1,7 @@
 import bunyan from 'bunyan'
 import config from '../config/config.js'
 
-const { logLevel } = config.getModuleConfig
+const { logLevel } = config.getModuleConfig()
 
 let obj
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed typo when getting `logLevel` from config to override default `info` level.

## Tested scenarios
Ran notification instance and checked if `logLevel` is passed correctly.

