### PR TITLE
feat: more logs for extension and notification apps

### DIFF
--- a/extension/src/api/payment/payment.controller.js
+++ b/extension/src/api/payment/payment.controller.js
@@ -28,15 +28,16 @@ async function processRequest(request, response, logger) {
   try {
     const authToken = getAuthorizationRequestHeader(request)
     paymentObject = await _getPaymentObject(request, logger)
-    logger.debug('Received payment object', JSON.stringify(paymentObject))
+    const paymentLogger = logger.child({ paymentId: paymentObject.id })
+    paymentLogger.debug('Received payment object', JSON.stringify(paymentObject))
     
-    logger.info('Handling payment...')
+    paymentLogger.info({ paymentId: paymentObject.id }, 'Handling payment...')
     const paymentResult = await paymentHandler.handlePayment(
       paymentObject,
       authToken,
     )
     const statusCode = paymentResult.actions ? 200 : 400
-    logger.info({ statusCode, errors: paymentResult.errors }, 'Payment handled')
+    paymentLogger.info({ statusCode, errors: paymentResult.errors }, 'Payment handled')
 
     const result = {
       response,
@@ -46,7 +47,7 @@ async function processRequest(request, response, logger) {
       : { errors: paymentResult.errors },
     }
 
-    logger.debug('Data to be returned', JSON.stringify(result.data))
+    paymentLogger.debug('Data to be returned', JSON.stringify(result.data))
 
     return httpUtils.sendResponse(result)
   } catch (err) {

--- a/extension/src/api/payment/payment.controller.js
+++ b/extension/src/api/payment/payment.controller.js
@@ -3,9 +3,7 @@ import httpUtils from '../../utils.js'
 import { getAuthorizationRequestHeader } from '../../validator/authentication.js'
 import paymentHandler from '../../paymentHandler/payment-handler.js'
 
-const logger = httpUtils.getLogger()
-
-async function processRequest(request, response) {
+async function processRequest(request, response, logger) {
   if (request.method !== 'POST') {
     // API extensions always calls this endpoint with POST, so if we got GET, we don't process further
     // https://docs.commercetools.com/api/projects/api-extensions#input
@@ -29,24 +27,30 @@ async function processRequest(request, response) {
   let paymentObject = {}
   try {
     const authToken = getAuthorizationRequestHeader(request)
-    paymentObject = await _getPaymentObject(request)
+    paymentObject = await _getPaymentObject(request, logger)
     logger.debug('Received payment object', JSON.stringify(paymentObject))
+    
+    logger.info('Handling payment...')
     const paymentResult = await paymentHandler.handlePayment(
       paymentObject,
       authToken,
     )
+    const statusCode = paymentResult.actions ? 200 : 400
+    logger.info({ statusCode, errors: paymentResult.errors }, 'Payment handled')
+
     const result = {
       response,
-      statusCode: paymentResult.actions ? 200 : 400,
+      statusCode,
       data: paymentResult.actions
-        ? { actions: paymentResult.actions }
-        : { errors: paymentResult.errors },
+      ? { actions: paymentResult.actions }
+      : { errors: paymentResult.errors },
     }
 
     logger.debug('Data to be returned', JSON.stringify(result.data))
 
     return httpUtils.sendResponse(result)
   } catch (err) {
+    logger.error(err, 'Error while handling payment')
     return httpUtils.sendResponse({
       response,
       statusCode: 400,
@@ -55,7 +59,7 @@ async function processRequest(request, response) {
   }
 }
 
-async function _getPaymentObject(request) {
+async function _getPaymentObject(request, logger) {
   let body = {}
   try {
     body = await httpUtils.collectRequestData(request)

--- a/extension/src/server.js
+++ b/extension/src/server.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import http from 'http'
 import url from 'url'
 import utils from './utils.js'
@@ -5,22 +6,34 @@ import { routes } from './routes.js'
 
 const logger = utils.getLogger()
 
+const calculateRequestDuration = (start) => new Date().getTime() - start
+
 function setupServer() {
   return http.createServer(async (request, response) => {
     const parts = url.parse(request.url)
     const route = routes[parts.pathname]
+    const startRequestMs = new Date().getTime()
+    const reqId = randomUUID()
+    const reqLogger = logger.child({ reqId, path: route, method: request.method })
 
-    if (route)
+    if (route) {
       try {
-        await route(request, response)
+        reqLogger.info('incoming request')
+        await route(request, response, reqLogger)
+        reqLogger.info(
+          { responseTime: calculateRequestDuration(startRequestMs) },
+          'request completed'
+        );
       } catch (e) {
-        logger.error(
+        reqLogger.error(
           e,
           `Unexpected error when processing URL ${JSON.stringify(parts)}`,
         )
         utils.sendResponse({ response, statusCode: 500 })
       }
-    else utils.sendResponse({ response, statusCode: 404 })
+    } else {
+      utils.sendResponse({ response, statusCode: 404 })
+    }
   })
 }
 

--- a/extension/src/server.js
+++ b/extension/src/server.js
@@ -24,9 +24,9 @@ function setupServer() {
           { responseTime: calculateRequestDuration(startRequestMs) },
           'request completed'
         );
-      } catch (e) {
+      } catch (err) {
         reqLogger.error(
-          e,
+          { err, responseTime: calculateRequestDuration(startRequestMs) },
           `Unexpected error when processing URL ${JSON.stringify(parts)}`,
         )
         utils.sendResponse({ response, statusCode: 500 })

--- a/extension/src/utils.js
+++ b/extension/src/utils.js
@@ -5,6 +5,9 @@ import path from 'path'
 import fs from 'node:fs/promises'
 import config from './config/config.js'
 
+/**
+ * @type {ReturnType<typeof bunyan.createLogger>}
+ */
 let logger
 
 function collectRequestData(request) {
@@ -28,12 +31,14 @@ function sendResponse({ response, statusCode = 200, headers, data }) {
 }
 
 function getLogger() {
-  if (!logger)
+  if (!logger) {
     logger = bunyan.createLogger({
       name: 'ctp-adyen-integration-extension',
       stream: process.stderr,
       level: config.getModuleConfig().logLevel || bunyan.INFO,
     })
+  }
+
   return logger
 }
 

--- a/extension/test/unit/payment.controller.spec.js
+++ b/extension/test/unit/payment.controller.spec.js
@@ -15,8 +15,6 @@ describe('Payment controller', () => {
   })
 
   describe('Validation', () => {
-    const mockRequest = { method: 'POST' }
-
     it('on missing required custom fields should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
 
@@ -41,8 +39,17 @@ describe('Payment controller', () => {
 
       sinon.stub(utils, 'collectRequestData').callsFake(collectRequestData)
       sinon.stub(utils, 'sendResponse').callsFake(sendResponse)
+      const mockRequest = { method: 'POST' }
+      const responseMock = {
+        writeHead: () => {},
+        end: () => {},
+      }
 
-      await paymentController.processRequest(mockRequest)
+      await paymentController.processRequest(
+        mockRequest,
+        responseMock,
+        utils.getLogger()
+      )
 
       utils.collectRequestData.restore()
       utils.sendResponse.restore()
@@ -69,7 +76,16 @@ describe('Payment controller', () => {
       sinon.stub(utils, 'sendResponse').callsFake(utilsSendResponse)
 
       const mockGetRequest = { method: 'GET' }
-      await paymentController.processRequest(mockGetRequest)
+      const responseMock = {
+        writeHead: () => {},
+        end: () => {},
+      }
+
+      await paymentController.processRequest(
+        mockGetRequest,
+        responseMock,
+        utils.getLogger()
+      )
 
       utils.sendResponse.restore()
       utils.collectRequestData.restore()
@@ -91,7 +107,17 @@ describe('Payment controller', () => {
     sinon.stub(utils, 'sendResponse').callsFake(sendResponse)
 
     const mockPostRequest = { method: 'POST' }
-    await paymentController.processRequest(mockPostRequest)
+    const responseMock = {
+      writeHead: () => {},
+      end: () => {},
+    }
+
+    await paymentController.processRequest(
+      mockPostRequest,
+      responseMock,
+      utils.getLogger()
+    )
+
     utils.sendResponse.restore()
   })
 })

--- a/notification/src/api/notification/notification.controller.js
+++ b/notification/src/api/notification/notification.controller.js
@@ -23,11 +23,12 @@ async function handleNotification(request, response, logger) {
       const ctpProjectConfig = getCtpProjectConfig(notification, parts.path)
       const adyenConfig = getAdyenConfig(notification)
 
-      await notificationHandler.processNotification(
+      await notificationHandler.processNotification({
         notification,
-        adyenConfig.enableHmacSignature,
+        enableHmacSignature: adyenConfig.enableHmacSignature,
         ctpProjectConfig,
-      )
+        logger,
+      })
     }
     return sendAcceptedResponse(response)
   } catch (err) {

--- a/notification/src/api/notification/notification.controller.js
+++ b/notification/src/api/notification/notification.controller.js
@@ -4,20 +4,19 @@ import utils from '../../utils/commons.js'
 import { isRecoverableError, getErrorCause } from '../../utils/error-utils.js'
 import notificationHandler from '../../handler/notification/notification.handler.js'
 import { getCtpProjectConfig, getAdyenConfig } from '../../utils/parser.js'
-import { getLogger } from '../../utils/logger.js'
 
-const logger = getLogger()
-
-async function handleNotification(request, response) {
+async function handleNotification(request, response, logger) {
   if (request.method !== 'POST') {
     logger.debug(
       `Received non-POST request: ${request.method}. The request will not be processed...`,
     )
     return utils.sendResponse(response)
   }
+
   const body = await utils.collectRequestData(request)
   try {
     const notifications = _.get(JSON.parse(body), 'notificationItems', [])
+
     for (const notification of notifications) {
       logger.debug('Received notification', JSON.stringify(notification))
       const parts = url.parse(request.url)

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -5,23 +5,21 @@ import { validateHmacSignature } from '../../utils/hmacValidator.js'
 import utils from '../../utils/commons.js'
 import ctp from '../../utils/ctp.js'
 import config from '../../config/config.js'
-import { getLogger } from '../../utils/logger.js'
 
-const mainLogger = getLogger()
-
-async function processNotification(
+async function processNotification({
   notification,
   enableHmacSignature,
   ctpProjectConfig,
-) {
-  const logger = mainLogger.child({
+  logger
+}) {
+  const ctpLogger = logger.child({
     commercetools_project_key: ctpProjectConfig.projectKey,
   })
 
   if (enableHmacSignature) {
     const errorMessage = validateHmacSignature(notification)
     if (errorMessage) {
-      logger.error(
+      ctpLogger.error(
         { notification: utils.getNotificationForTracking(notification) },
         `HMAC validation failed. Reason: "${errorMessage}"`,
       )
@@ -107,7 +105,7 @@ async function processNotification(
         )
       }
 
-      logger.error(err)
+      ctpLogger.error(err, 'Error while updating payment')
     }
   }
 

--- a/notification/src/server.js
+++ b/notification/src/server.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import http from 'http'
 import url from 'url'
 import utils from './utils/commons.js'
@@ -5,6 +6,8 @@ import { routes } from './routes.js'
 import { getLogger } from './utils/logger.js'
 
 const logger = getLogger()
+
+const calculateRequestDuration = (start) => new Date().getTime() - start
 
 function getHandlerNameFromUrl(parts) {
   return parts.path?.split('/')?.slice(-2)?.[0] ?? ''
@@ -15,17 +18,32 @@ function setupServer() {
     const parts = url.parse(request.url)
     const path = getHandlerNameFromUrl(parts)
     const route = routes[`/${path}`]
-    if (route)
+    const startRequestMs = new Date().getTime()
+    const reqId = randomUUID()
+    const reqLogger = logger.child({
+      reqId,
+      path: route,
+      method: request.method,
+    })
+
+    if (route) {
       try {
-        await route(request, response)
+        reqLogger.info('incoming request')
+        await route(request, response, reqLogger)
+        reqLogger.info(
+          { responseTime: calculateRequestDuration(startRequestMs) },
+          'request completed',
+        )
       } catch (err) {
-        logger.error(
-          err,
+        reqLogger.error(
+          { err, responseTime: calculateRequestDuration(startRequestMs) },
           `Unexpected error when processing URL ${JSON.stringify(parts)}`,
         )
         utils.sendResponse(response, 500)
       }
-    else utils.sendResponse(response, 404)
+    } else {
+      utils.sendResponse(response, 404)
+    }
   })
 }
 

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -12,6 +12,7 @@ import { buildMockErrorFromConcurrentModificationException } from '../test-utils
 const { cloneDeep } = lodash
 const logger = getLogger()
 const sandbox = sinon.createSandbox()
+
 describe('notification controller', () => {
   const commercetoolsProjectKey = config.getAllCtpProjectKeys()[0]
   const ctpConfig = config.getCtpConfig(commercetoolsProjectKey)
@@ -43,7 +44,6 @@ describe('notification controller', () => {
 
   let originalCollectRequestDataFn
   let originalLogErrorFn
-  let logSpy
 
   before(() => {
     originalCollectRequestDataFn = utils.collectRequestData
@@ -74,15 +74,17 @@ describe('notification controller', () => {
       const notificationJson = cloneDeep(mockNotificationJson)
       utils.collectRequestData = () => JSON.stringify(notificationJson)
 
-      logSpy = sinon.spy()
-      logger.error = logSpy
+      const loggerMock = {
+        error: sinon.spy(),
+        debug: logger.debug,
+      }
 
       // test:
-      await handleNotification(requestMock, responseMock)
-      const { cause } = logSpy.firstCall.args[0]
+      await handleNotification(requestMock, responseMock, loggerMock)
+      const { cause } = loggerMock.error.firstCall.args[0]
       // expect:
       expect(responseWriteHeadSpy.firstCall.firstArg).to.equal(200)
-      expect(logSpy.calledOnce).to.be.true
+      expect(loggerMock.error.calledOnce).to.be.true
       expect(responseEndSpy.firstCall.firstArg).to.equal(
         JSON.stringify({ notificationResponse: '[accepted]' }),
       )
@@ -120,15 +122,17 @@ describe('notification controller', () => {
       .callsFake(() => ({}))
     config.getCtpConfig = configGetCtpConfigSpy
 
-    logSpy = sinon.spy()
-    logger.error = logSpy
+    const loggerMock = {
+      error: sinon.spy(),
+      debug: logger.debug,
+    }
 
     // test:
-    await handleNotification(requestMock, responseMock)
-    const { cause } = logSpy.firstCall.args[0]
+    await handleNotification(requestMock, responseMock, loggerMock)
+    const { cause } = loggerMock.error.firstCall.args[0]
     // expect:
     expect(responseWriteHeadSpy.firstCall.firstArg).to.equal(200)
-    expect(logSpy.calledOnce).to.be.true
+    expect(loggerMock.error.calledOnce).to.be.true
     expect(responseEndSpy.firstCall.firstArg).to.equal(
       JSON.stringify({ notificationResponse: '[accepted]' }),
     )
@@ -157,16 +161,18 @@ describe('notification controller', () => {
       }
     utils.collectRequestData = () => JSON.stringify(notificationJson)
 
-    logSpy = sinon.spy()
-    logger.error = logSpy
+    const loggerMock = {
+      error: sinon.spy(),
+      debug: logger.debug,
+    }
 
     // test:
-    await handleNotification(requestMock, responseMock)
+    await handleNotification(requestMock, responseMock, loggerMock)
 
-    const { cause } = logSpy.firstCall.args[0]
+    const { cause } = loggerMock.error.firstCall.args[0]
     // expect:
     expect(responseWriteHeadSpy.firstCall.firstArg).to.equal(200)
-    expect(logSpy.calledOnce).to.be.true
+    expect(loggerMock.error.calledOnce).to.be.true
     expect(responseEndSpy.firstCall.firstArg).to.equal(
       JSON.stringify({ notificationResponse: '[accepted]' }),
     )
@@ -210,8 +216,10 @@ describe('notification controller', () => {
       const notificationJson = mockNotificationJson
       utils.collectRequestData = () => JSON.stringify(notificationJson)
 
-      logSpy = sinon.spy()
-      logger.error = logSpy
+      const loggerMock = {
+        error: sinon.spy(),
+        debug: logger.debug,
+      }
 
       notificationJson.notificationItems[0].NotificationRequestItem.additionalData =
         {
@@ -229,10 +237,10 @@ describe('notification controller', () => {
       config.getAdyenConfig = configGetAdyenConfigSpy
 
       // test:
-      await handleNotification(requestMock, responseMock)
-      const { cause } = logSpy.firstCall.args[0]
+      await handleNotification(requestMock, responseMock, loggerMock)
+      const { cause } = loggerMock.error.firstCall.args[0]
 
-      expect(logSpy.calledOnce).to.be.true
+      expect(loggerMock.error.calledOnce).to.be.true
       expect(cause.body.message).to.equal(
         'Object 62f05181-4789-47ce-84f8-d27c895ee23c has a different version than expected. Expected: 1 - Actual: 2.',
       )

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -219,6 +219,7 @@ describe('notification controller', () => {
       const loggerMock = {
         error: sinon.spy(),
         debug: logger.debug,
+        child: logger.child,
       }
 
       notificationJson.notificationItems[0].NotificationRequestItem.additionalData =

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -13,6 +13,8 @@ import {
   buildMockErrorFromConcurrentModificationException,
 } from '../test-utils.js'
 import utils from '../../src/utils/commons.js'
+import { getLogger } from '../../src/utils/logger.js'
+
 const { expect } = chai
 const { cloneDeep } = lodash
 const sandbox = sinon.createSandbox()
@@ -201,11 +203,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger(),
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -304,11 +307,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger(),
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -507,11 +511,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger()
+    })
     // assert
     expect(ctpClientUpdateSpy.callCount).to.equal(1)
 
@@ -568,11 +573,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger()
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -668,11 +674,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger()
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -768,11 +775,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger()
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -878,11 +886,12 @@ describe('notification module', () => {
     ctp.get = () => ctpClient
 
     // process
-    await notificationHandler.processNotification(
-      notifications[0],
-      false,
-      config,
-    )
+    await notificationHandler.processNotification({
+      notification: notifications[0],
+      enableHmacSignature: false,
+      ctpProjectConfig: config,
+      logger: getLogger()
+    })
     if (config.getModuleConfig().removeSensitiveData) {
       delete notifications[0].NotificationRequestItem.additionalData
     }
@@ -954,11 +963,12 @@ describe('notification module', () => {
     let err
     // process
     try {
-      await notificationHandler.processNotification(
-        notificationsMock[0],
-        false,
-        config,
-      )
+      await notificationHandler.processNotification({
+        notification: notificationsMock[0],
+        enableHmacSignature: false,
+        ctpProjectConfig: config,
+        logger: getLogger(),
+      })
     } catch (e) {
       // we check retry logic here and it should throw after certain amount
       // of retries. So the error is expected
@@ -1022,11 +1032,12 @@ describe('notification module', () => {
       ctp.get = () => ctpClient
 
       // process
-      await notificationHandler.processNotification(
-        notifications[0],
-        false,
-        config,
-      )
+      await notificationHandler.processNotification({
+        notification: notifications[0],
+        enableHmacSignature: false,
+        ctpProjectConfig: config,
+        logger: getLogger(),
+      })
 
       expect(ctpClientUpdateSpy.args[0][3][0].fields.notification).to.include(
         'additionalData',
@@ -1090,11 +1101,12 @@ describe('notification module', () => {
       ctp.get = () => ctpClient
 
       // process
-      await notificationHandler.processNotification(
-        notifications[0],
-        false,
-        config,
-      )
+      await notificationHandler.processNotification({
+        notification: notifications[0],
+        enableHmacSignature: false,
+        ctpProjectConfig: config,
+        logger: getLogger(),
+      })
 
       expect(
         ctpClientUpdateSpy.args[0][3][0].fields.notification,
@@ -1151,11 +1163,12 @@ describe('notification module', () => {
     let error
     // process
     try {
-      await notificationHandler.processNotification(
-        notifications[0],
-        false,
-        config,
-      )
+      await notificationHandler.processNotification({
+        notification: notifications[0],
+        enableHmacSignature: false,
+        ctpProjectConfig: config,
+        logger: getLogger(),
+      })
     } catch (e) {
       error = e
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The motivation behind this PR is that I would like to observe better what's going on in the extension and notification applications. I would like to track a whole request path by request id and have a response time.

In my PR I inject a logger instead of importing it from utils. The injected logger has a context of the request, it contains information about the requesting path, used HTTP method, and request id. In my opinion, it's better to have a context instead of a raw logger without anything.

Also, I changed the notification handler to accept an object. This approach is more flexible in case of adding new things in the future and it provides more context for the developer, especially for the boolean values, now you don't have to remember the order of the arguments. 

## Tested scenarios

Not much to test here, I added logs 😉😄
