### PR TITLE
fix(lambda): Set proper handler return value for lambda as ALB target

### DIFF
--- a/extension/index.lambda.js
+++ b/extension/index.lambda.js
@@ -9,8 +9,8 @@ let handler = async (event) => {
   try {
     const body = event.body ? JSON.parse(event.body) : event
     paymentObj = body?.resource?.obj
-    if (!paymentObj)
-      return {
+    if (!paymentObj) {
+      const responseBody = {
         responseType: 'FailedValidation',
         errors: [
           {
@@ -20,6 +20,16 @@ let handler = async (event) => {
         ],
       }
 
+      return {
+        statusCode: 200,
+        isBase64Encoded: false,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(responseBody),
+      }
+    }
+
     const authToken = getAuthorizationRequestHeader(event)
 
     logger.debug('Received payment object', JSON.stringify(paymentObj))
@@ -28,7 +38,7 @@ let handler = async (event) => {
       paymentObj,
       authToken,
     )
-    const result = {
+    const responseBody = {
       responseType: paymentResult.actions
         ? 'UpdateRequest'
         : 'FailedValidation',
@@ -36,13 +46,28 @@ let handler = async (event) => {
       actions: paymentResult.actions || [],
     }
 
-    logger.debug('Data to be returned', JSON.stringify(result))
+    logger.debug('Data to be returned', JSON.stringify(responseBody))
 
-    return result
+    return {
+      statusCode: 200,
+      isBase64Encoded: false,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(responseBody),
+    }
   } catch (e) {
     const errorObj = utils.handleUnexpectedPaymentError(paymentObj, e)
     errorObj.responseType = 'FailedValidation'
-    return errorObj
+
+    return {
+      statusCode: 200,
+      isBase64Encoded: false,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(errorObj),
+    }
   }
 }
 

--- a/notification/index.lambda.js
+++ b/notification/index.lambda.js
@@ -50,7 +50,16 @@ export const handler = async (event) => {
     }
   }
 
-  return {
+  const responseBody = {
     notificationResponse: '[accepted]',
+  }
+
+  return {
+    statusCode: 200,
+    isBase64Encoded: false,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(responseBody),
   }
 }


### PR DESCRIPTION
Lambda in AWS can be configured as Target Group for ALB. API Gateway, Lambda Function URL and Application Load Balancer expect lambda to return an object with specific fields, e.g. `statusCode` which have a special behavior (response object). Not specifying `statusCode` field in lambda and triggering it by API Gateway or Function URL converts return object into a string and returns it with status code 200. ALB throws 502 Bad Gateway error instead, expecting lambda to return a proper response object structure with at least `statusCode` field (the rest including `body` seems to be optional).

To keep it compatible with all three solutions and avoid potential conflict between returned body and response object structure, object returned by the lambda should have a proper structure. To keep it compatible with current behavior, status is set to 200 and the body is stringified and returned as the lambda response object `body` field.

API Gateway response body:
https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-types-transforms

Lambda Function url response body (follows API Gateway structure):
https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads

ALB Target group response body:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#respond-to-load-balancer