### PR TITLE
docs: add missing view_customers scope note to HowToRun.md

### DIFF
--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -76,8 +76,7 @@ Extension module requires 1 environment variable to start. This environment vari
   - For **live environment** follow the official Adyen [documentation](https://docs.adyen.com/user-management/get-started-with-adyen#step-2-apply-for-your-live-account) for details.
 - commercetools project credentials:
   - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
-    - Note that extension module requires `manage_payments, view_orders, view_customers` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
-    - Note: The extension requires the `view_customers` scope to read customer data; if you change scopes you must recreate the API client to apply the new scopes.
+    - Note that the extension module requires `manage_payments, view_orders, view_customers` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration (the `view_customers` scope is needed to read customer data), and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources. If you change scopes, you must recreate the API client to apply the new scopes.
 
 ### Required attributes
 

--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -77,7 +77,7 @@ Extension module requires 1 environment variable to start. This environment vari
 - commercetools project credentials:
   - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
     - Note that extension module requires `manage_payments, view_orders, view_customers` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
-    - Note: The extension requires the `view_customers:{projectKey}` scope to read customer data; if you change scopes you must recreate the API client to apply the new scopes.
+    - Note: The extension requires the `view_customers` scope to read customer data; if you change scopes you must recreate the API client to apply the new scopes.
 
 ### Required attributes
 

--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -76,7 +76,8 @@ Extension module requires 1 environment variable to start. This environment vari
   - For **live environment** follow the official Adyen [documentation](https://docs.adyen.com/user-management/get-started-with-adyen#step-2-apply-for-your-live-account) for details.
 - commercetools project credentials:
   - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
-    - Note that extension module requires `manage_payments, view_orders` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
+    - Note that extension module requires `manage_payments, view_orders, view_customers` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
+    - Note: The extension requires the `view_customers:{projectKey}` scope to read customer data; if you change scopes you must recreate the API client to apply the new scopes.
 
 ### Required attributes
 


### PR DESCRIPTION
- Updated HowToRun.md to clarify OAuth scope requirements.
- Added a short note that the extension requires view_customers:{projectKey} in addition to manage_payments and view_orders so it can read customer data.
- Mentioned that changing scopes requires recreating the API client in Commercetools to apply new scopes.
- This is a documentation-only change; no code changes were made.

**Fixed issue**:  [1275](https://github.com/Adyen/adyen-commercetools/issues/1275)